### PR TITLE
fix: bump concurrent-ruby 1.1.9 -> 1.3.7 (security)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.9)
     colorator (1.1.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.3.7)
     csv (3.3.3)
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)


### PR DESCRIPTION
## O que
Atualiza `concurrent-ruby` de `1.1.9` para `1.3.7` no `Gemfile.lock`.

## Por quê
Corrige 3 alertas de segurança do Dependabot:
- **#12 (High)** — `AtomicReference#update` livelock quando o valor é `Float::NAN`
- **#11 (Low)** — `ReadWriteLock` permite release de write em thread errada / corrupção do contador de read-release
- **#10 (Low)** — overflow no contador de reads do `ReentrantReadWriteLock` concedendo write lock sem exclusividade

## Impacto
Dependência **transitiva** (`jekyll` → `i18n`/`tzinfo`, constraint `~> 1.0`). A `1.3.7` é a última estável, satisfaz todas as constraints e não tem dependências próprias — nenhuma outra linha do lockfile mudou.

## Validação
Build rodada no container `jekyll/builder:latest` (mesma imagem da CI):
- ✅ `bundle install` — `concurrent-ruby (1.3.7)` resolvido/instalado
- ✅ `bundle exec jekyll build --future` — site gerado sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)